### PR TITLE
Use address from etcd-init secret directly for join

### DIFF
--- a/controllers/etcdadmconfig_controller.go
+++ b/controllers/etcdadmconfig_controller.go
@@ -294,8 +294,13 @@ func (r *EtcdadmConfigReconciler) joinEtcd(ctx context.Context, scope *Scope) (_
 		return ctrl.Result{}, errors.Wrap(err, "failed doing a lookup for certs during join")
 	}
 
-	initMachineAddress := string(existingSecret.Data["address"])
-	joinAddress := fmt.Sprintf("https://%v:2379", initMachineAddress)
+	var joinAddress string
+	if clientURL, ok := existingSecret.Data["clientUrls"]; ok {
+		joinAddress = string(clientURL)
+	} else {
+		initMachineAddress := string(existingSecret.Data["address"])
+		joinAddress = fmt.Sprintf("https://%v:2379", initMachineAddress)
+	}
 
 	joinInput := userdata.EtcdPlaneJoinInput{
 		BaseUserData: userdata.BaseUserData{


### PR DESCRIPTION
Till now the etcd-init secret contained an IP address of one of the
etcd members. The bootstrap-provider then converted it into etcd client URL
before passing it in to the `etcdadm join` command.
With recent changes in the etcdadm-controller and cluster-api patches,
this secret will always containg either a single etcd client URL in case
of cluster creation, or a comma seprated list of client URLs for all members.
This commit changes the bootstrap-provider to directly use the value stored
in Secret.